### PR TITLE
Fix issue with not proceeding past all-link reports:

### DIFF
--- a/lib/Insteon/index.js
+++ b/lib/Insteon/index.js
@@ -674,10 +674,10 @@ Insteon.prototype.checkStatus = function () {
       return; // still buffering
     }
     debug('checkStatus - ALL-Link Cleanup Status Report');
+    this.buffer = raw.substr(6);
     if(!status) {
       return;
     }
-    this.buffer = raw.substr(6);
     status.report = {
       completed: raw.substr(4, 2) === '06',
       aborted: raw.substr(4, 2) === '15'


### PR DESCRIPTION
If you go around your house pressing buttons on a scene keypad,
all-link status reports are going to arrive.

If your code is not currently sending outgoing commands (just waiting
on events) the parser "chokes" on the all-link status message and will
never proceed, and buffer will grow forever.