### PR TITLE
All-link command response is always 6 bytes.

### DIFF
--- a/lib/Insteon/index.js
+++ b/lib/Insteon/index.js
@@ -701,21 +701,15 @@ Insteon.prototype.checkStatus = function () {
     status.success = true;
     break;
   case '0261': // ALL-Link Command
-    if(raw.length < 10) {
-      return; // still buffering
-    }
-    debug('checkStatus - ALL-Link Command');
-    if(!status) {
-      this.buffer = raw.substr(10);
-      this.emit('recvCommand', {type: '61', raw: raw.substr(0,10)});
-      break; // TODO: this.emit('command', parsedCmd);
-    }
     if(raw.length < 12) {
       return; // still buffering
     }
-    this.emit('recvCommand', {type: '61', raw: raw.substr(0,12)});
-
+    debug('checkStatus - ALL-Link Command');
     this.buffer = raw.substr(12);
+    this.emit('recvCommand', {type: '61', raw: raw.substr(0,12)});
+    if(!status) {
+      break; // TODO: this.emit('command', parsedCmd);
+    }
     status.ack =raw.substr(10, 2) === '06';
     status.nack =raw.substr(10, 2) === '15';
     break;


### PR DESCRIPTION
When an all-link command arrives from the IM to host, per the Modem
Developer's Guide, it's always 6 bytes. The previous behavior left an
extra hex pair on the front of the buffer.

It's possible to receive All-link commands coming from linked
responders even if you didn't originate a scene control command
yourself, if user has a scene control keypad.