### PR TITLE
Make incoming message parser more resilient.

### DIFF
--- a/lib/Insteon/index.js
+++ b/lib/Insteon/index.js
@@ -25,6 +25,11 @@ var DEV_CAT_NAMES = utils.DEV_CAT_NAMES;
 
 var DEDUP_TIMER = 5000; // 5 seconds
 
+// responses
+var MESSAGE_PROCESSED = 1;  // signals the caller that a message was consumed.
+var INSUFFICIENT_DATA = 2; // signals the caller that insufficient data is there to proceed.
+var MESSAGE_SKIPPED = 3;   // signals the caller that we skipped a message. Temporary.
+
 var Light = require('./Light');
 var Thermostat = require('./Thermostat');
 var Motion = require('./Motion');
@@ -542,8 +547,30 @@ Insteon.prototype.handleCommand = function (device, cmd) {
   debug('No event for command message type for device (%s) : ', device.id, cmd);
 };
 
-
 Insteon.prototype.checkStatus = function () {
+  var that = this;
+  var result = this._checkStatus();
+  switch (result) {
+    case INSUFFICIENT_DATA:
+      debug('parsing - insufficient data to continue - %d', this.buffer.length);
+      break;
+    case MESSAGE_PROCESSED:
+    case MESSAGE_SKIPPED:
+      // If a message was consumed or skipped
+      debug('parsing - message %s', ((result === MESSAGE_PROCESSED)? 'consumed': 'skipped'));
+      if (this.buffer) {
+        // Run this again, but allow the message loop a chance to wake up.
+        setTimeout(function() { that.checkStatus(); }, 0);
+      }
+      break;
+    default:
+      debug('parsing - unknown result %s', result);
+  }
+};
+
+
+Insteon.prototype._checkStatus = function () {
+  var result; // Just trying to be careful and suss out every single path
   var raw = this.buffer;
   debug('checkStatus - buffer: %s', raw);
   var status = this.status;
@@ -551,7 +578,7 @@ Insteon.prototype.checkStatus = function () {
 
   var cmd, id;
   if(raw.length <= 2) {
-    return; // buffering
+    return INSUFFICIENT_DATA; // buffering
   }
 
   var nextCmdAt = raw.search(/02(5[0-8]|6[0-9a-f]|7[0-3])/i);
@@ -565,7 +592,7 @@ Insteon.prototype.checkStatus = function () {
   switch(type.toUpperCase()) {
   case '0250': // Standard Command
     if(raw.length < 22) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
     debug('checkStatus - Standard Command');
     this.buffer = raw.substr(22);
@@ -582,6 +609,7 @@ Insteon.prototype.checkStatus = function () {
     }
     if(!status || !status.command || !status.command.id ||
       (status.command.id.toUpperCase() !== id)) { // command isn't a response for a command we sent
+      result = MESSAGE_SKIPPED;
       this.emit('command', cmd);
       break;
     }
@@ -599,7 +627,7 @@ Insteon.prototype.checkStatus = function () {
         (!status.command.extended || !!status.command.isStandardResponse) &&
         !status.command.waitForExtended && !status.command.waitForLinking;
     }
-
+    result = MESSAGE_PROCESSED;
     break;
   case '0251': // Extended Command
     if(raw.length < 50) {
@@ -627,6 +655,7 @@ Insteon.prototype.checkStatus = function () {
     if(!status || !status.command || !status.command.id ||
       status.command.id.toUpperCase() !== id) { // command isn't a response for a command we sent
       this.emit('command', cmd);
+      result = MESSAGE_SKIPPED;
       break;
     }
     if(!status.response) {
@@ -634,10 +663,11 @@ Insteon.prototype.checkStatus = function () {
     }
     status.response.extended = cmd.extended;
     status.success = cmd.extended !== undefined && cmd.extended !== null;
+    result = MESSAGE_PROCESSED;
     break;
   case '0253': // Link Command
     if(raw.length < 20) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
     debug('checkStatus - Link Command');
     this.buffer = raw.substr(20);
@@ -652,26 +682,28 @@ Insteon.prototype.checkStatus = function () {
     }
     status.response.link = cmd.link;
     status.success = cmd.link !== undefined && cmd.link !== null;
+    result = MESSAGE_PROCESSED;
     break;
   case '0257'://
     if(raw.length < 20) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
     debug('checkStatus - Link Record Command');
-    if(!status) {
-      return;
-    }
     this.buffer = raw.substr(20);
+    if(!status) {
+      return MESSAGE_SKIPPED;
+    }
     status.response = {};
     status.response.raw = raw;
     status.response.type = raw.substr(2, 2);
     status.response.link = parseLinkRecord(raw.substr(4,16));
     this.emit('recvCommand', status.response);
     status.success = true;
+    result = MESSAGE_PROCESSED;
     break;
   case '0258'://
     if(raw.length < 6) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
     debug('checkStatus - ALL-Link Cleanup Status Report');
     this.buffer = raw.substr(6);
@@ -684,111 +716,139 @@ Insteon.prototype.checkStatus = function () {
     };
     this.emit('recvCommand', {type: '58', raw: raw.substr(0,6), report: status.report});
     status.success = true;
+    result = MESSAGE_SKIPPED;
     break;
   case '0260': // Get IM Info
     if(raw.length < 18) {
-      return; // still buffering
-    }
-    debug('checkStatus - Get IM Info Command');
-    if(!status) {
-      return;
+      return INSUFFICIENT_DATA; // still buffering
     }
     this.buffer = raw.substr(18);
+    debug('checkStatus - Get IM Info Command');
+    if(!status) {
+      return MESSAGE_SKIPPED;
+    }
     status.ack =raw.substr(16, 2) === '06';
     status.nack =raw.substr(16, 2) === '15';
     status.response = parseGetInfo(raw.substr(0,16));
     this.emit('recvCommand', status.response);
     status.success = true;
+    result = MESSAGE_PROCESSED;
     break;
   case '0261': // ALL-Link Command
     if(raw.length < 12) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
     debug('checkStatus - ALL-Link Command');
     this.buffer = raw.substr(12);
     this.emit('recvCommand', {type: '61', raw: raw.substr(0,12)});
     if(!status) {
+      result = MESSAGE_SKIPPED;
       break; // TODO: this.emit('command', parsedCmd);
     }
     status.ack =raw.substr(10, 2) === '06';
     status.nack =raw.substr(10, 2) === '15';
+    result = MESSAGE_PROCESSED;
     break;
-  case '0262':
-    if(!status) {
-      this.buffer = raw.substr(4);
-      return;
+  case '0262': // Response to a standard or extended message, usually direct
+    if (raw.length < 12) {
+      return INSUFFICIENT_DATA;
     }
-    if(raw.length < status.command.raw.length + 2) {
-      return; // still buffering
-    }
+
     debug('checkStatus - Direct Command');
+    if(!status) {
+      // The interesting thing about an 0262 is it's a variable length response.
+      // So unlike the other responses, we need to get to the message flags byte to know
+      // whether it's a standard (18 hex chars) or extended (46 hex chars) response.
+      var flags = parseInt(raw.substr(10, 2), 16);
+      var isExtended = (flags & 0x10) !== 0;
+      var expectedLength = isExtended? 46 : 18;
+      if (raw.length < expectedLength) {
+        return INSUFFICIENT_DATA;
+      }
+
+      this.buffer = raw.substr(expectedLength);
+      return MESSAGE_SKIPPED;
+    }
+
+    // probably redundant now, but keeping it
+    if(raw.length < status.command.raw.length + 2) {
+      return INSUFFICIENT_DATA; // still buffering
+    }
+
     this.emit('recvCommand', {type: '62', raw: raw.substr(0, status.command.raw.length + 2)});
     this.buffer = raw.substr(status.command.raw.length + 2);
     status.ack = raw.substr(status.command.raw.length, 2) === '06';
     status.nack = raw.substr(status.command.raw.length, 2) === '15';
+    result = MESSAGE_PROCESSED;
     break;
-  case '0263':
-    if(!status) {
-      this.buffer = raw.substr(4);
-      return;
+  case '0263': // X10 response
+    if(raw.length < 10) {
+      return INSUFFICIENT_DATA; // still buffering
     }
-    if(raw.length < status.command.raw.length + 2) {
-      return; // still buffering
+    this.buffer = raw.substr(10);
+    if (!status) {
+      // If we get here, we got an X10 response without sending a request. Probably nowhere to route it.
+      return MESSAGE_SKIPPED;
     }
+
     debug('checkStatus - X10 Command');
     this.emit('recvCommand', {type: '63', raw: raw.substr(0, status.command.raw.length + 2)});
-    this.buffer = raw.substr(status.command.raw.length + 2);
     status.ack = raw.substr(status.command.raw.length, 2) === '06';
     status.nack = raw.substr(status.command.raw.length, 2) === '15';
     break;
   case '0264':
-    if(!status) {
-      return;
-    }
     if(raw.length < 10) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
-    this.emit('recvCommand', {type: '64', raw: raw.substr(0,10)});
     this.buffer = raw.substr(10);
+
+    if(!status) {
+      return MESSAGE_SKIPPED;
+    }
+
+    this.emit('recvCommand', {type: '64', raw: raw.substr(0,10)});
     status.ack = raw.substr(8, 2) === '06';
     status.nack = raw.substr(8, 2) === '15';
     status.success = !status.command.waitForLinking;
     break;
   case '0265':
-    if(!status) {
-      return;
-    }
     if(raw.length < 6) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
     }
-    this.emit('recvCommand', {type: '65', raw: raw.substr(0,6)});
     this.buffer = raw.substr(6);
+
+    if(!status) {
+      return MESSAGE_SKIPPED;
+    }
+
+    this.emit('recvCommand', {type: '65', raw: raw.substr(0,6)});
     status.ack =raw.substr(4, 2) === '06';
     status.nack =raw.substr(4, 2) === '15';
     status.success = true;
     break;
   case '0269':
   case '026A':
-    if(!status) {
-      return;
-    }
     if(raw.length < 6) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
+    }
+    this.buffer = raw.substr(6);
+    if(!status) {
+      return MESSAGE_SKIPPED;
     }
     this.emit('recvCommand', {type: raw.substr(2,2), raw: raw.substr(0,6)});
-    this.buffer = raw.substr(6);
     status.ack =raw.substr(4, 2) === '06';
     status.nack =raw.substr(4, 2) === '15';
+    result = MESSAGE_PROCESSED;
     break;
   case '026F':
-    if(!status) {
-      return;
-    }
     if(raw.length < 24) {
-      return; // still buffering
+      return INSUFFICIENT_DATA; // still buffering
+    }
+    this.buffer = raw.substr(24);
+    if(!status) {
+      return MESSAGE_SKIPPED;
     }
     this.emit('recvCommand', {type: '6F', raw: raw.substr(0,24)});
-    this.buffer = raw.substr(24);
     status.ack =raw.substr(22, 2) === '06';
     status.nack =raw.substr(22, 2) === '15';
     status.command.code = raw.substr(4, 2);
@@ -819,9 +879,7 @@ Insteon.prototype.checkStatus = function () {
 
     }
   }
-  if(this.buffer.length > 2) { // needs to be at least a full command
-    this.checkStatus();
-  }
+  return result; // return the parsing result we're using for discovery of parser states.
 };
 
 function parseRecieved(raw) {


### PR DESCRIPTION
Make the parser more resilient to these cases:
* Incoming messages bunched into a single TCP read would end up
  causing message buffer to "fall behind" - especially with various
  integrations or a busy insteon network.
* Messages of some response types coming in when you thought you
  weren't expecting one would make the parser get 'stuck' sometimes
  forever. (mostly happens with the insteon hub gateway and using the
  app at the same time)
* Add in auditability to the checkStatus to see when it is possible to
  proceed and when we are definitely waiting for more data.