### PR TITLE
Dispatcher refactor: Turn checkStatus into a function dispatcher

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+    "env": {
+        "commonjs": true,
+        "node": true,
+        "es6": false
+    },
+    "extends": "eslint:recommended",
+    "installedESLint": true,
+    "parserOptions": {
+        "ecmaVersion": 5,
+        "ecmaFeatures": {
+        },
+        "sourceType": "module"
+    },
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "semi": "error",
+    },
+    "globals": {
+        "process": true,
+    }
+};

--- a/lib/Insteon/index.js
+++ b/lib/Insteon/index.js
@@ -53,7 +53,8 @@ var Insteon = function () {
   this.devices = {};
 
   this.emitDuplicates = false;
-
+  // Clone the dispatchers to allow clients to override/customize if desired
+  this.dispatchers = Object.assign({}, DISPATCHERS);
 };
 
 
@@ -551,23 +552,22 @@ Insteon.prototype.checkStatus = function () {
   var that = this;
   var result = this._checkStatus();
   switch (result) {
-    case INSUFFICIENT_DATA:
-      debug('parsing - insufficient data to continue - %d', this.buffer.length);
-      break;
-    case MESSAGE_PROCESSED:
-    case MESSAGE_SKIPPED:
-      // If a message was consumed or skipped
-      debug('parsing - message %s', ((result === MESSAGE_PROCESSED)? 'consumed': 'skipped'));
-      if (this.buffer) {
-        // Run this again, but allow the message loop a chance to wake up.
-        setTimeout(function() { that.checkStatus(); }, 0);
-      }
-      break;
-    default:
-      debug('parsing - unknown result %s', result);
+  case INSUFFICIENT_DATA:
+    debug('parsing - insufficient data to continue - %d', this.buffer.length);
+    break;
+  case MESSAGE_PROCESSED:
+  case MESSAGE_SKIPPED:
+    // If a message was consumed or skipped
+    debug('parsing - message %s', ((result === MESSAGE_PROCESSED)? 'consumed': 'skipped'));
+    if (this.buffer) {
+      // Run this again, but allow the message loop a chance to wake up.
+      setTimeout(function() { that.checkStatus(); }, 0);
+    }
+    break;
+  default:
+    debug('parsing - unknown result %s', result);
   }
 };
-
 
 Insteon.prototype._checkStatus = function () {
   var result; // Just trying to be careful and suss out every single path
@@ -576,8 +576,7 @@ Insteon.prototype._checkStatus = function () {
   var status = this.status;
   debug('checkStatus - status: %j', status);
 
-  var cmd, id;
-  if(raw.length <= 2) {
+  if(raw.length <= 4) {
     return INSUFFICIENT_DATA; // buffering
   }
 
@@ -588,20 +587,62 @@ Insteon.prototype._checkStatus = function () {
 
   var type = raw.substr(0, 4);
 
-  var msgType;
-  switch(type.toUpperCase()) {
-  case '0250': // Standard Command
-    if(raw.length < 22) {
-      return INSUFFICIENT_DATA; // still buffering
+  // Dispatcher-style handling
+  var dispatcher = this.dispatchers[type.toUpperCase()];
+  if (dispatcher) {
+    var rawMsg = dispatcher.checkSize.call(this, raw);
+    if (rawMsg === false) {
+      return INSUFFICIENT_DATA;
     }
-    debug('checkStatus - Standard Command');
-    this.buffer = raw.substr(22);
-    cmd = parseRecieved(raw);
+    debug('checkStatus - dispatcher - %s', dispatcher.name);
+    result = dispatcher.handler.call(this, rawMsg, status);
+    if (result !== MESSAGE_SKIPPED) {
+      this.trailer();
+    }
+    return result;
+  } else {
+    if (this.buffer.length > 4) {
+      this.buffer = this.buffer.substr(4);
+    } else {
+      this.buffer = '';
+    }
+    return MESSAGE_SKIPPED;
+  }
+};
+
+var DISPATCHERS = {};
+
+// A closure factory to build the checkSize function for most of our handlers
+function _defaultCheckSize(size) {
+  return function(raw) {
+    if (raw.length < size) {
+      return false;
+    }
+    this.buffer = raw.substr(size);
+    return raw.substr(0, size);
+  };
+}
+
+function setupDispatcher(dispatcher) {
+  if (!dispatcher.checkSize) {
+    if (!dispatcher.size) {
+      throw new Error('Dispatcher missing checkSize and size');
+    }
+    dispatcher.checkSize = _defaultCheckSize(dispatcher.size);
+  }
+  DISPATCHERS[dispatcher.id] = dispatcher;
+}
+
+setupDispatcher({
+  id: '0250',
+  name: 'Standard Command',
+  size: 22,
+  handler: function(raw, status) {
+    var cmd = parseRecieved(raw);
     this.emit('recvCommand', cmd);
     debug('Parsed command: %j', cmd);
     debug('Status: %j', status);
-    msgType = cmd.standard.messageType;
-    id = cmd.standard.id.toUpperCase();
+    var id = cmd.standard.id.toUpperCase();
     debug('Devices: %j', Object.keys(this.devices));
     if(this.devices[id]) {
       debug('Handle Command for device: %s', id);
@@ -609,9 +650,8 @@ Insteon.prototype._checkStatus = function () {
     }
     if(!status || !status.command || !status.command.id ||
       (status.command.id.toUpperCase() !== id)) { // command isn't a response for a command we sent
-      result = MESSAGE_SKIPPED;
       this.emit('command', cmd);
-      break;
+      return MESSAGE_SKIPPED;
     }
     if(!status.response) {
       status.response = {};
@@ -627,15 +667,16 @@ Insteon.prototype._checkStatus = function () {
         (!status.command.extended || !!status.command.isStandardResponse) &&
         !status.command.waitForExtended && !status.command.waitForLinking;
     }
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0251': // Extended Command
-    if(raw.length < 50) {
-      return; // still buffering
-    }
-    debug('checkStatus - Extended Command');
-    this.buffer = raw.substr(50);
-    cmd = parseRecieved(raw);
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0251',
+  name: 'Extended Command',
+  size: 50,
+  handler: function(raw, status) {
+    var cmd = parseRecieved(raw);
 
     // Calculate if CRC is valid (not use by most commands)
     var fullCmd = cmd.extended.command1 + cmd.extended.command2;
@@ -647,83 +688,79 @@ Insteon.prototype._checkStatus = function () {
     this.emit('recvCommand', cmd);
     debug('Parsed command: %j', cmd);
     debug('Status: %j', status);
-    msgType = cmd.extended.messageType;
-    id = cmd.extended.id.toUpperCase();
+    var id = cmd.extended.id.toUpperCase();
     if(this.devices[id]) {
       this.handleCommand(this.devices[id], cmd);
     }
     if(!status || !status.command || !status.command.id ||
       status.command.id.toUpperCase() !== id) { // command isn't a response for a command we sent
       this.emit('command', cmd);
-      result = MESSAGE_SKIPPED;
-      break;
+      return MESSAGE_SKIPPED;
     }
     if(!status.response) {
       status.response = {};
     }
     status.response.extended = cmd.extended;
     status.success = cmd.extended !== undefined && cmd.extended !== null;
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0253': // Link Command
-    if(raw.length < 20) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    debug('checkStatus - Link Command');
-    this.buffer = raw.substr(20);
-    cmd = parseRecieved(raw);
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0253',
+  name: 'Link Command',
+  size: 20,
+  handler: function(raw, status) {
+    var cmd = parseRecieved(raw);
     this.emit('recvCommand', cmd);
     if(!status) {
       this.emit('command', cmd);
-      break;
+      return MESSAGE_PROCESSED;
     }
     if(!status.response) {
       status.response = {};
     }
     status.response.link = cmd.link;
     status.success = cmd.link !== undefined && cmd.link !== null;
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0257'://
-    if(raw.length < 20) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    debug('checkStatus - Link Record Command');
-    this.buffer = raw.substr(20);
-    if(!status) {
-      return MESSAGE_SKIPPED;
-    }
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0257',
+  name: 'Link Record Command',
+  size: 20,
+  handler: function(raw, status) {
     status.response = {};
     status.response.raw = raw;
     status.response.type = raw.substr(2, 2);
     status.response.link = parseLinkRecord(raw.substr(4,16));
     this.emit('recvCommand', status.response);
     status.success = true;
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0258'://
-    if(raw.length < 6) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    debug('checkStatus - ALL-Link Cleanup Status Report');
-    this.buffer = raw.substr(6);
-    if(!status) {
-      return;
-    }
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0258',
+  name: 'All-Link Cleanup Status Report',
+  size: 6,
+  handler: function(raw, status) {
     status.report = {
       completed: raw.substr(4, 2) === '06',
       aborted: raw.substr(4, 2) === '15'
     };
     this.emit('recvCommand', {type: '58', raw: raw.substr(0,6), report: status.report});
     status.success = true;
-    result = MESSAGE_SKIPPED;
-    break;
-  case '0260': // Get IM Info
-    if(raw.length < 18) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    this.buffer = raw.substr(18);
-    debug('checkStatus - Get IM Info Command');
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0260',
+  name: 'Get IM Info Response',
+  size: 18,
+  handler: function(raw, status) {
     if(!status) {
       return MESSAGE_SKIPPED;
     }
@@ -732,60 +769,64 @@ Insteon.prototype._checkStatus = function () {
     status.response = parseGetInfo(raw.substr(0,16));
     this.emit('recvCommand', status.response);
     status.success = true;
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0261': // ALL-Link Command
-    if(raw.length < 12) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    debug('checkStatus - ALL-Link Command');
-    this.buffer = raw.substr(12);
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0261',
+  name: 'All-Link Command Response',
+  size: 12,
+  handler: function(raw, status) {
     this.emit('recvCommand', {type: '61', raw: raw.substr(0,12)});
     if(!status) {
-      result = MESSAGE_SKIPPED;
-      break; // TODO: this.emit('command', parsedCmd);
+      return MESSAGE_SKIPPED; // TODO: this.emit('command', parsedCmd);
     }
     status.ack =raw.substr(10, 2) === '06';
     status.nack =raw.substr(10, 2) === '15';
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0262': // Response to a standard or extended message, usually direct
+    return MESSAGE_PROCESSED;
+  }
+});
+
+// Response to a standard or extended message, usually direct
+setupDispatcher({
+  id: '0262',
+  name: 'Direct Command Response',
+  checkSize: function(raw) {
+    // Under 12 characters, we don't have the flags byte, so we need more.
     if (raw.length < 12) {
-      return INSUFFICIENT_DATA;
+      return false;
+    }
+    // The interesting thing about an 0262 is it's a variable length response.
+    // So unlike the other responses, we need to get to the message flags byte to know
+    // whether it's a standard (18 hex chars) or extended (46 hex chars) response.
+    var flags = parseInt(raw.substr(10, 2), 16);
+    var isExtended = (flags & 0x10) !== 0;
+    var expectedLength = isExtended? 46 : 18;
+    if (raw.length < expectedLength) {
+      return false;
     }
 
-    debug('checkStatus - Direct Command');
-    if(!status) {
-      // The interesting thing about an 0262 is it's a variable length response.
-      // So unlike the other responses, we need to get to the message flags byte to know
-      // whether it's a standard (18 hex chars) or extended (46 hex chars) response.
-      var flags = parseInt(raw.substr(10, 2), 16);
-      var isExtended = (flags & 0x10) !== 0;
-      var expectedLength = isExtended? 46 : 18;
-      if (raw.length < expectedLength) {
-        return INSUFFICIENT_DATA;
-      }
-
-      this.buffer = raw.substr(expectedLength);
+    this.buffer = raw.substr(expectedLength);
+    return raw.substr(0, expectedLength);
+  },
+  handler: function(raw, status) {
+    if (!this.status) {
       return MESSAGE_SKIPPED;
     }
 
-    // probably redundant now, but keeping it
-    if(raw.length < status.command.raw.length + 2) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-
     this.emit('recvCommand', {type: '62', raw: raw.substr(0, status.command.raw.length + 2)});
-    this.buffer = raw.substr(status.command.raw.length + 2);
     status.ack = raw.substr(status.command.raw.length, 2) === '06';
     status.nack = raw.substr(status.command.raw.length, 2) === '15';
-    result = MESSAGE_PROCESSED;
-    break;
-  case '0263': // X10 response
-    if(raw.length < 10) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    this.buffer = raw.substr(10);
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0263', // X10 response
+  name: 'X10 Response',
+  size: 10,
+  handler: function(raw, status) {
     if (!status) {
       // If we get here, we got an X10 response without sending a request. Probably nowhere to route it.
       return MESSAGE_SKIPPED;
@@ -795,13 +836,14 @@ Insteon.prototype._checkStatus = function () {
     this.emit('recvCommand', {type: '63', raw: raw.substr(0, status.command.raw.length + 2)});
     status.ack = raw.substr(status.command.raw.length, 2) === '06';
     status.nack = raw.substr(status.command.raw.length, 2) === '15';
-    break;
-  case '0264':
-    if(raw.length < 10) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    this.buffer = raw.substr(10);
+  }
+});
 
+setupDispatcher({
+  id: '0264',
+  name: 'All-Link Start Response',
+  size: 10,
+  handler: function(raw, status) {
     if(!status) {
       return MESSAGE_SKIPPED;
     }
@@ -810,13 +852,14 @@ Insteon.prototype._checkStatus = function () {
     status.ack = raw.substr(8, 2) === '06';
     status.nack = raw.substr(8, 2) === '15';
     status.success = !status.command.waitForLinking;
-    break;
-  case '0265':
-    if(raw.length < 6) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    this.buffer = raw.substr(6);
+  }
+});
 
+setupDispatcher({
+  id: '0265',
+  name: 'ALL-Link Cancel Response',
+  size: 6,
+  handler: function(raw, status) {
     if(!status) {
       return MESSAGE_SKIPPED;
     }
@@ -825,26 +868,37 @@ Insteon.prototype._checkStatus = function () {
     status.ack =raw.substr(4, 2) === '06';
     status.nack =raw.substr(4, 2) === '15';
     status.success = true;
-    break;
-  case '0269':
-  case '026A':
-    if(raw.length < 6) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    this.buffer = raw.substr(6);
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '0269',
+  name: 'Get First ALL-Link Record',
+  size: 6,
+  handler: function(raw, status) {
     if(!status) {
       return MESSAGE_SKIPPED;
     }
     this.emit('recvCommand', {type: raw.substr(2,2), raw: raw.substr(0,6)});
     status.ack =raw.substr(4, 2) === '06';
     status.nack =raw.substr(4, 2) === '15';
-    result = MESSAGE_PROCESSED;
-    break;
-  case '026F':
-    if(raw.length < 24) {
-      return INSUFFICIENT_DATA; // still buffering
-    }
-    this.buffer = raw.substr(24);
+    return MESSAGE_PROCESSED;
+  }
+});
+
+setupDispatcher({
+  id: '026A',
+  name: 'Get Next ALL-Link Record',
+  size: 6,
+  handler: DISPATCHERS['0269'].handler
+});
+
+setupDispatcher({
+  id: '026F',
+  name: 'Manage ALL-Link Record Response',
+  size: 24,
+  handler: function(raw, status) {
     if(!status) {
       return MESSAGE_SKIPPED;
     }
@@ -855,14 +909,11 @@ Insteon.prototype._checkStatus = function () {
     if(status.command.code !== '00' && status.command.code !== '01') {
       status.success = status.ack;
     }
-    break;
-  default:
-    if(this.buffer.length > raw.length) {
-      this.buffer = this.buffer.substr(raw.length);
-    } else {
-      this.buffer = '';
-    }
   }
+});
+
+Insteon.prototype.trailer = function() {
+  var status = this.status;
   debug('checkStatus - status (after parsing): %j', status);
   if(status) {
     if(status.command.exitOnAck) {
@@ -879,7 +930,6 @@ Insteon.prototype._checkStatus = function () {
 
     }
   }
-  return result; // return the parsing result we're using for discovery of parser states.
 };
 
 function parseRecieved(raw) {

--- a/test/Insteon.js
+++ b/test/Insteon.js
@@ -3989,6 +3989,72 @@ describe('Insteon Gateway', function () {
         }, 10);
       });
     });
+
+    it('handles a randomly arriving extended command (0251)', function(done) {
+      var gw = new Insteon();
+      var plan = new Plan(2, done);
+      gw.on('command', function() {
+        plan.ok();
+      });
+      gw.connect(host, function () {
+        setTimeout(function () { // make sure server connection event fires first
+          mockHub.send([
+            '0251112233ffffff112e0001010000202018fc7f0000000000'
+          ], function () { plan.ok(); });
+        }, 10);
+      });
+    });
+
+    it('handles a randomly arriving link completed command (0253)', function(done) {
+      var gw = new Insteon();
+      var plan = new Plan(2, done);
+      gw.on('command', function() {
+        plan.ok();
+      });
+      gw.connect(host, function () {
+        setTimeout(function () { // make sure server connection event fires first
+          mockHub.send([
+            '0253010111223301204100'
+          ], function () { plan.ok(); });
+        }, 10);
+      });
+    });
+
+    function skippedCheck(buffer, done) {
+      var gw = new Insteon();
+      gw.connect(host, function () {
+        gw.buffer = buffer;
+        var result = gw._checkStatus();
+        result.should.equal(3); // MESSAGE_SKIPPED = 3
+        gw.buffer.should.equal('');
+        done();
+      });
+    }
+
+    it('skips a randomly arriving X10 Response (0263)', function(done) {
+      skippedCheck('0263000000', done);
+    });
+
+    it('skips a randomly arriving All-Link start response (0264)', function(done) {
+      skippedCheck('0264000000', done);
+    });
+
+    it('skips a randomly arriving All-Link cancel response (0265)', function(done) {
+      skippedCheck('026506', done);
+    });
+
+    it('skips a randomly arriving All-Link records response (0269)', function(done) {
+      skippedCheck('026906', done);
+    });
+
+    it('skips a randomly arriving All-Link records Next response (026A)', function(done) {
+      skippedCheck('026A06', done);
+    });
+
+    it('skips a randomly arriving manage all-link response (026F)', function(done) {
+      skippedCheck('026f40c23226b1cc7f190006', done);
+    });
+
   }); // End parser consistency tests
 
   describe('Util tests', function () {


### PR DESCRIPTION
Instead of a big case-block, instead implement methods for each
handler, and descriptors for each that remove boilerplate like the
very common grabbing a certain number of bytes, printing messages, and
rejecting messages with certain criteria.

This dispatcher setup also opens the avenue for easier plugging in of
new messages by allowing library users to work with `gw.dispatchers`